### PR TITLE
fix!: arm64 tag overwrites x86_64

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -109,7 +109,7 @@ steps:
       repo: miwpayou0808/misskey
       tags: 
         - latest-arm64
-        - "${DRONE_COMMIT_SHA:0:7}"
+        - "${DRONE_COMMIT_SHA:0:7}-arm64"
       username:
         from_secret: dockerhub_username
       password:
@@ -128,7 +128,7 @@ steps:
       repo: miwpayou0808/misskey
       tags: 
         - edge-arm64
-        - "${DRONE_COMMIT_SHA:0:7}"
+        - "${DRONE_COMMIT_SHA:0:7}-arm64"
       username:
         from_secret: dockerhub_username
       password:


### PR DESCRIPTION
## Summary

commit hashを使用しているタグ指定がarm64かx86_64の両方で同じなためpull時にアーキテクチャがどちらかしか選べない問題を修正(大抵はビルドが遅いarm64で上書きになってしまう)

![実行形式エラー](https://media-miwkey.miwpayou0808.info/main-media/3ab404f8-6b7e-4cac-976c-c4d31e92a751.png)